### PR TITLE
ECCW-649: Deprecated function error.

### DIFF
--- a/ecc_cookie_compliance.module
+++ b/ecc_cookie_compliance.module
@@ -31,7 +31,7 @@ function ecc_cookie_compliance_preprocess_field(&$variables) {
 function ecc_cookie_compliance_page_attachments(&$variables) {
   $variables['#attached']['library'][] = 'ecc_cookie_compliance/live_handler';
   $host = \Drupal::request()->getSchemeAndHttpHost();
-  $request = \Drupal::request()->headers->get('referer');
+  $request = \Drupal::request()->headers->get('referer') ?? '';
   $prev_destination = str_replace($host, "", $request);
   $variables['#attached']['drupalSettings']['path']['prevDestination'] = $prev_destination;
 }


### PR DESCRIPTION
Small fix for PHP debug message
`Deprecated function: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in ecc_cookie_compliance_page_attachments() (line 36 of /var/www/html/web/modules/contrib/ecc_cookie_compliance/ecc_cookie_compliance.module)`