### PR TITLE
Set cookie banner to static so it does not hide toolbar menu.

### DIFF
--- a/css/ecc_cookie.css
+++ b/css/ecc_cookie.css
@@ -62,3 +62,7 @@
     height: 14px;
     height: .875rem
 }
+
+.user-logged-in .sliding-popup-top {
+  position: static;
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/94a54de8-cda6-4099-951d-d02ecc549bef)
