### PR TITLE
Text case change, link classes and more specific link styles

### DIFF
--- a/css/ecc_cookie.css
+++ b/css/ecc_cookie.css
@@ -77,7 +77,7 @@
   color: #fff;
 }
 
-.cookies-message > p > a.cookies-link,
+.cookies-message a.cookies-link,
 .cookies-message h3 {
   color: #fff;
 }

--- a/css/ecc_cookie.css
+++ b/css/ecc_cookie.css
@@ -77,7 +77,7 @@
   color: #fff;
 }
 
-.cookies-message a,
+.cookies-message > p > a.cookies-link,
 .cookies-message h3 {
   color: #fff;
 }

--- a/ecc_cookie_compliance.module
+++ b/ecc_cookie_compliance.module
@@ -108,7 +108,7 @@ function _cookies_video_preprocess_field_item_link(&$item) {
   $item['content']['#type'] = 'container';
   $item['content']['#attributes']['class'] = ['cookies-message'];
   $item['content']['message'] = [
-    '#markup' => t("<h3>Video Unavailable</h3><p>It looks like you’ve declined cookies, which means we can’t show you this video. Cookies help us provide a better experience by remembering your preferences and enabling video playback.</p><p>If you’d like to watch the video, please consider accepting cookies. You can <a href='/cookies'>update your cookie preferences</a> here. </p><p>Thank you for understanding!</p>"),
+    '#markup' => t("<h3>Video unavailable</h3><p>It looks like you’ve declined cookies, which means we can’t show you this video. Cookies help us provide a better experience by remembering your preferences and enabling video playback.</p><p>If you’d like to watch the video, please consider accepting cookies. You can <a class='cookies-link' href='/cookies'>update your cookie preferences</a> here. </p><p>Thank you for understanding!</p>"),
   ];
   $item['content']['link'] = [
     '#type' => 'html_tag',
@@ -117,6 +117,7 @@ function _cookies_video_preprocess_field_item_link(&$item) {
       'href' => $src,
       'title' => $title,
       'target' => '_blank',
+      'class' => ['cookies-link'],
     ],
     '#value' => $title,
   ];


### PR DESCRIPTION
We made the video unavailable message use sentence case for the heading, not title case.
We add in classes for links for greater specificity in styling.
https://eccservicetransformation.atlassian.net/browse/LP-238